### PR TITLE
[BE] Ref: 댓글 쿼리 성능 향상

### DIFF
--- a/src/main/java/com/ncp/moeego/comment/entity/Comment.java
+++ b/src/main/java/com/ncp/moeego/comment/entity/Comment.java
@@ -1,15 +1,22 @@
 package com.ncp.moeego.comment.entity;
 
 import com.ncp.moeego.article.bean.Article;
+import com.ncp.moeego.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.Data;
-import com.ncp.moeego.member.entity.Member;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Data
+@Table(
+        name = "comment",
+        indexes = {
+                @Index(name = "idx_article_write_date", columnList = "article_no, write_date")
+        }
+)
 public class Comment {
 
     @Id

--- a/src/main/java/com/ncp/moeego/comment/repository/CommentRepository.java
+++ b/src/main/java/com/ncp/moeego/comment/repository/CommentRepository.java
@@ -24,6 +24,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
                 c.writeDate)
             FROM Comment c
             WHERE c.member.memberNo = :memberNo
+            ORDER BY c.writeDate ASC
             """)
     Page<MemberCommentResponse> findByMember_MemberNo(@Param("memberNo") Long memberNo, Pageable pageable);
 
@@ -33,6 +34,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             SELECT c
             FROM Comment c
             WHERE c.article.articleNo = :articleNo AND c.parent IS NULL
+            ORDER BY c.writeDate ASC
             """)
     Page<Comment> findParentCommentsByArticle(@Param("articleNo") Long articleNo, Pageable pageable);
 

--- a/src/main/java/com/ncp/moeego/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/ncp/moeego/comment/service/CommentServiceImpl.java
@@ -86,7 +86,7 @@ public class CommentServiceImpl implements CommentService {
     //회원 ID로 댓글 조회
     @Override
     public Page<MemberCommentResponse> findCommentsByMember(Long memberNo, int pg, int pageSize) {
-        Pageable pageable = PageRequest.of(pg-1, pageSize, Sort.by("writeDate").ascending());
+        Pageable pageable = PageRequest.of(pg-1, pageSize);
         return commentRepository.findByMember_MemberNo(memberNo, pageable);
     }
 
@@ -105,7 +105,7 @@ public class CommentServiceImpl implements CommentService {
     @Override
     public Page<CommentResponse> findPagedCommentsByArticle(Long articleNo, int pg, int pagesize) {
 
-        Pageable pageable = PageRequest.of(pg-1, pagesize, Sort.by("writeDate").ascending());
+        Pageable pageable = PageRequest.of(pg-1, pagesize);
 
         Page<Comment> commentList = commentRepository.findParentCommentsByArticle(articleNo, pageable);
 


### PR DESCRIPTION
# 수정한 내용
- 댓글 쿼리 성능 개선
# 상세내용
- Comment 엔티티에서  idx_article_write_date 로 복합인덱싱
- 서비스계층에서 write_date로 sort했던걸 db에서 정렬해서 가져오게 변경
- 댓글 800개 기준 전보다 로딩시간 1/5 정도로 줄어듬(articleNo=11)