### PR TITLE
[BE] Feat: 달인 회원가입 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     //jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    //JWT
+    // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.5'

--- a/src/main/java/com/ncp/moeego/article/bean/Article.java
+++ b/src/main/java/com/ncp/moeego/article/bean/Article.java
@@ -1,13 +1,10 @@
 package com.ncp.moeego.article.bean;
 
-import com.ncp.moeego.comment.entity.Comment;
 import com.ncp.moeego.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.Data;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Data
@@ -43,11 +40,6 @@ public class Article {
     
     @Column(length = 200)
     private String area;
-    
-    // 댓글 목록을 추가하여 양방향 관계 설정
-    @OneToMany(mappedBy = "article", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
-    private List<Comment> comments = new ArrayList<>(); // 댓글 리스트 추가
-    
 
     @Override
     public String toString() {

--- a/src/main/java/com/ncp/moeego/article/repository/ArticleRepository.java
+++ b/src/main/java/com/ncp/moeego/article/repository/ArticleRepository.java
@@ -3,6 +3,7 @@ package com.ncp.moeego.article.repository;
 import java.util.List;
 import java.util.Optional;
 
+import com.ncp.moeego.article.bean.Article;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -10,8 +11,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import com.ncp.moeego.article.bean.Article;
 
 @Repository
 public interface ArticleRepository extends JpaRepository<Article, Long>{
@@ -50,13 +49,10 @@ public interface ArticleRepository extends JpaRepository<Article, Long>{
 	@Query("SELECT a FROM Article a WHERE a.memberNo.memberNo = :memberNo")
 	Page<Article> findByMemberNo(@Param("memberNo") Long memberNo, Pageable pageable);
 
-	// 전체 게시글 댓글 수 가져오는 쿼리
-	@Query("SELECT a, COUNT(c) FROM Article a LEFT JOIN Comment c ON a.articleNo = c.article.articleNo " +
-		       "AND c.commentStatus != 'DELETED' " +  // 여기서 'DELETED' 댓글만 제외 현식이 요청사항 ^^...
-		       "WHERE a.type NOT IN (0, 1) " +      // 게시글 type이 0, 1인 것 제외 현식이 요청사항 ^^...
-		       "GROUP BY a.articleNo")
+	// 댓글 수 가져오는 쿼리
+	@Query("SELECT a, COUNT(c) FROM Article a LEFT JOIN Comment c ON a.articleNo = c.article.articleNo AND c.commentStatus != 'DELETED' GROUP BY a.articleNo")
 	Page<Object[]> findArticlesWithCommentCount(Pageable pageable);
-    
+	
 	// 타입별 댓글 수 가져오는 쿼리
 	@Query("SELECT a, COUNT(c) FROM Article a LEFT JOIN Comment c ON a.articleNo = c.article.articleNo AND c.commentStatus != 'DELETED' WHERE a.type = :type GROUP BY a")
 	Page<Object[]> findTypeArticlesWithCommentCount(@Param("type") int type, Pageable pageable);
@@ -65,6 +61,9 @@ public interface ArticleRepository extends JpaRepository<Article, Long>{
 	@Query("SELECT a, COUNT(c) FROM Article a LEFT JOIN Comment c ON a.articleNo = c.article.articleNo AND c.commentStatus != 'DELETED' WHERE a.memberNo.memberNo = :memberNo GROUP BY a")
 	Page<Object[]> findMyArticlesWithCommentCount(@Param("memberNo") Long memberNo, Pageable pageable);
 
+	// 상세 페이지 댓글 수 가져오는 쿼리
+	@Query("SELECT a, COUNT(c) FROM Article a LEFT JOIN Comment c ON a.articleNo = c.article.articleNo AND c.commentStatus != 'DELETED' WHERE a.articleNo = :articleNo GROUP BY a")
+	Optional<Object[]> findArticleWithCommentCount(@Param("articleNo") Long articleNo);
 
 	// 좋아요 순 댓글 수 가져오는 쿼리
 	@Query("SELECT a, COUNT(c) FROM Article a LEFT JOIN Comment c ON a.articleNo = c.article.articleNo AND c.commentStatus != 'DELETED' GROUP BY a ORDER BY a.likes DESC")

--- a/src/main/java/com/ncp/moeego/article/service/ArticleServiceImpl.java
+++ b/src/main/java/com/ncp/moeego/article/service/ArticleServiceImpl.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import com.ncp.moeego.article.bean.Article;
 import com.ncp.moeego.article.bean.ArticleDTO;
 import com.ncp.moeego.article.repository.ArticleRepository;
-import com.ncp.moeego.comment.repository.CommentRepository;
 import com.ncp.moeego.common.Date;
 import com.ncp.moeego.member.entity.Member;
 import com.ncp.moeego.member.repository.MemberRepository;
@@ -26,7 +25,7 @@ public class ArticleServiceImpl implements ArticleService {
 
     private final ArticleRepository articleRepository;
     private final MemberRepository memberRepository;
-    private final CommentRepository commentRepository;
+   
     // memberNo맞춰서 이름 가져오는 로직
     public String getMemberNameByMemberNo(Long memberNo) {
         Optional<Member> member = memberRepository.findById(memberNo); // memberNo로 Member 조회
@@ -215,41 +214,38 @@ public class ArticleServiceImpl implements ArticleService {
     // 게시글 상세 조회
     @Override
     public ArticleDTO getArticleViewById(Long articleNo) {
-        // 게시글을 조회할 repository 호출 (예시: ArticleRepository)
-        Article article = articleRepository.findById(articleNo)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글 번호입니다."));
+        // 단일 쿼리로 게시글과 댓글 수를 함께 조회
+        Optional<Object[]> result = articleRepository.findArticleWithCommentCount(articleNo);
 
-        // 조회된 Article 엔티티를 ArticleDTO로 변환하여 반환
-        ArticleDTO articleDTO = new ArticleDTO();
-        articleDTO.setArticleNo(article.getArticleNo());
-        articleDTO.setMemberNo(article.getMemberNo().getMemberNo());
-        articleDTO.setSubject(article.getSubject());
-        articleDTO.setContent(article.getContent());
-        articleDTO.setView(article.getView());
-        articleDTO.setType(article.getType());
-        articleDTO.setWriteDate(article.getWriteDate());
-        articleDTO.setLikes(article.getLikes());
-        
+        // 게시글이 없으면 null 반환
+        if (!result.isPresent()) {
+            return null;
+        }
+
+        Object[] data = result.get();
+        Article article = (Article) data[0];
+        Long commentCount = (Long) data[1];
+
+        // 게시글이 존재하면 ArticleDTO로 변환하여 반환
         String elapsedTime = Date.calculateDate(article.getWriteDate());
         String memberName = getMemberNameByMemberNo(article.getMemberNo().getMemberNo());
-     
-        // 시간을 포맷하여 변환
-        articleDTO.setElapsedTime(elapsedTime);
         
-        // 작성자 이름, 서비스, 지역 등의 추가 정보를 설정
-        articleDTO.setMemberName(memberName);
-        articleDTO.setService(article.getService());
-        articleDTO.setArea(article.getArea());
-        
-        // 댓글 수 설정 (쿼리에서 가져온 값 사용)
-        Long commentCount = commentRepository.countNonDeletedCommentsByArticleNo(articleNo);
-        articleDTO.setCommentCount(commentCount.intValue());
-
-
-        return articleDTO;
-
+        return new ArticleDTO(
+            article.getArticleNo(),
+            article.getSubject(),
+            article.getContent(),
+            article.getView(),
+            article.getType(),
+            article.getWriteDate(),
+            article.getMemberNo().getMemberNo(),
+            article.getLikes(),
+            elapsedTime,
+            memberName,
+            article.getService(),
+            article.getArea(),
+            commentCount.intValue()
+        );
     }
-    
 
     // 마이페이지 작성한 게시글 조회
     @Override

--- a/src/main/java/com/ncp/moeego/category/repository/MainCategoryRepository.java
+++ b/src/main/java/com/ncp/moeego/category/repository/MainCategoryRepository.java
@@ -2,7 +2,9 @@ package com.ncp.moeego.category.repository;
 
 import com.ncp.moeego.category.bean.MainCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface MainCategoryRepository extends JpaRepository<MainCategory, Long>{
 
 }

--- a/src/main/java/com/ncp/moeego/category/repository/SubCategoryRepository.java
+++ b/src/main/java/com/ncp/moeego/category/repository/SubCategoryRepository.java
@@ -7,7 +7,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.ncp.moeego.category.bean.SubCategory;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface SubCategoryRepository extends JpaRepository<SubCategory, Long> {
 
 

--- a/src/main/java/com/ncp/moeego/comment/repository/CommentRepository.java
+++ b/src/main/java/com/ncp/moeego/comment/repository/CommentRepository.java
@@ -37,9 +37,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             ORDER BY c.writeDate ASC
             """)
     Page<Comment> findParentCommentsByArticle(@Param("articleNo") Long articleNo, Pageable pageable);
-
-    // 상세 게시글 댓글 수 카운트
-    @Query("SELECT COUNT(c) FROM Comment c WHERE c.article.articleNo = :articleNo AND c.commentStatus != 'DELETED'")
-    Long countNonDeletedCommentsByArticleNo(@Param("articleNo") Long articleNo);
     
 }

--- a/src/main/java/com/ncp/moeego/member/bean/JoinDTO.java
+++ b/src/main/java/com/ncp/moeego/member/bean/JoinDTO.java
@@ -1,10 +1,13 @@
 package com.ncp.moeego.member.bean;
 
 import com.ncp.moeego.member.entity.Member;
+import com.ncp.moeego.pro.dto.ProJoinRequest;
 import lombok.Data;
 
 @Data
 public class JoinDTO {
+
+
     private String email;
     private String name;
     private String pwd;
@@ -12,11 +15,23 @@ public class JoinDTO {
     private String phone;
     private String address;
 
+    public JoinDTO() {
+    }
+
     public JoinDTO(Member member) {
         this.email = member.getEmail();
         this.name = member.getName();
         this.gender = member.getGender();
         this.phone = member.getPhone();
         this.address = member.getAddress();
+    }
+
+    public JoinDTO(ProJoinRequest request) {
+        this.email = request.getEmail();
+        this.name = request.getName();
+        this.pwd = request.getPwd();
+        this.gender = request.getGender();
+        this.phone = request.getPhone();
+        this.address = request.getAddress();
     }
 }

--- a/src/main/java/com/ncp/moeego/member/controller/MemberController.java
+++ b/src/main/java/com/ncp/moeego/member/controller/MemberController.java
@@ -25,5 +25,10 @@ public class MemberController {
         if(check) return ResponseEntity.ok("ok");
         else return  ResponseEntity.badRequest().body("값이 잘못 되었습니다");
     }
+
+    @PostMapping("/join/exist")
+    public boolean isExistEmail(String email) {
+        return memberService.isExist(email);
+    }
     
 }

--- a/src/main/java/com/ncp/moeego/member/service/MemberService.java
+++ b/src/main/java/com/ncp/moeego/member/service/MemberService.java
@@ -10,6 +10,6 @@ public interface MemberService {
     Member getMemberById(Long memberNo);
     String getMemberName(Long memberNo);
     String getMemberProfileImage(Long memberNo);
-
+    boolean isExist(String email);
 
 }

--- a/src/main/java/com/ncp/moeego/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/ncp/moeego/member/service/impl/MemberServiceImpl.java
@@ -8,10 +8,12 @@ import com.ncp.moeego.member.repository.MemberRepository;
 import com.ncp.moeego.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import com.ncp.moeego.member.bean.JoinDTO;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
@@ -23,9 +25,6 @@ public class MemberServiceImpl implements MemberService {
     public boolean write(JoinDTO joinDTO) {
         String email = joinDTO.getEmail();
         String pwd = joinDTO.getPwd();
-
-        Boolean isExist = memberRepository.existsByEmail(email);
-        if(isExist) return false;
 
         Member data = new Member();
 
@@ -40,6 +39,11 @@ public class MemberServiceImpl implements MemberService {
 
         memberRepository.save(data);
         return true;
+    }
+
+    @Override
+    public boolean isExist(String email){
+        return memberRepository.existsByEmail(email);
     }
 
     @Override
@@ -58,5 +62,17 @@ public class MemberServiceImpl implements MemberService {
         return getMemberById(memberNo).getProfileImage();
     }
 
+    public Long getMemberNo(String email) {
+        log.info(memberRepository.findByEmail(email).getMemberNo().toString());
+        return memberRepository.findByEmail(email).getMemberNo();
+
+    }
+
+    @Transactional
+    public void setMemberStatus(Long memberNo, MemberStatus memberStatus) {
+        Member member = memberRepository.findById(memberNo).orElseThrow(()-> new IllegalArgumentException("Invalid memberNo"));
+        member.setMemberStatus(memberStatus);
+        log.debug("MemberNo: {}, MemberStatus: {}", member.getMemberNo(), member.getMemberStatus());
+    }
 
 }

--- a/src/main/java/com/ncp/moeego/pro/bean/Pro.java
+++ b/src/main/java/com/ncp/moeego/pro/bean/Pro.java
@@ -5,7 +5,6 @@ import java.util.Date;
 
 import com.ncp.moeego.category.bean.MainCategory;
 import com.ncp.moeego.category.bean.SubCategory;
-import com.ncp.moeego.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -37,7 +36,7 @@ public class Pro {
 	private SubCategory subCateNo;
 
 	@ManyToOne // 고수는 여러개의 예약신청을 받을수도 있고 예약을 못 받을수도있음
-	@JoinColumn(name = "reserve_no")
+	@JoinColumn(name = "reserve_no", nullable = false)
     private Reserve reserveNo;
 
 	@Column(name = "deprive_date")
@@ -47,10 +46,6 @@ public class Pro {
 	private LocalDateTime accessDate;
 
 	private float star;
-
-	@OneToOne
-	@JoinColumn(name = "member_no", nullable = false)
-	private Member member;
 	
 	@Column(name = "one_intro", length = 1000)
 	private String oneIntro; // 한줄소개

--- a/src/main/java/com/ncp/moeego/pro/bean/Pro.java
+++ b/src/main/java/com/ncp/moeego/pro/bean/Pro.java
@@ -5,6 +5,7 @@ import java.util.Date;
 
 import com.ncp.moeego.category.bean.MainCategory;
 import com.ncp.moeego.category.bean.SubCategory;
+import com.ncp.moeego.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -36,7 +37,7 @@ public class Pro {
 	private SubCategory subCateNo;
 
 	@ManyToOne // 고수는 여러개의 예약신청을 받을수도 있고 예약을 못 받을수도있음
-	@JoinColumn(name = "reserve_no", nullable = false)
+	@JoinColumn(name = "reserve_no", nullable = true)
     private Reserve reserveNo;
 
 	@Column(name = "deprive_date")
@@ -46,6 +47,10 @@ public class Pro {
 	private LocalDateTime accessDate;
 
 	private float star;
+
+	@OneToOne
+	@JoinColumn(name = "member_no", nullable = false)
+	private Member member;
 	
 	@Column(name = "one_intro", length = 1000)
 	private String oneIntro; // 한줄소개

--- a/src/main/java/com/ncp/moeego/pro/bean/Pro.java
+++ b/src/main/java/com/ncp/moeego/pro/bean/Pro.java
@@ -1,5 +1,6 @@
 package com.ncp.moeego.pro.bean;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 import com.ncp.moeego.category.bean.MainCategory;
@@ -39,10 +40,10 @@ public class Pro {
     private Reserve reserveNo;
 
 	@Column(name = "deprive_date")
-	private Date depriveDate;
+	private LocalDateTime depriveDate;
 
 	@Column(name = "access_date")
-	private Date accessDate;
+	private LocalDateTime accessDate;
 
 	private float star;
 	
@@ -51,4 +52,5 @@ public class Pro {
 	
 	@Column(length = 3000)
 	private String intro; // 서비스 소개
+
 }

--- a/src/main/java/com/ncp/moeego/pro/controller/ProController.java
+++ b/src/main/java/com/ncp/moeego/pro/controller/ProController.java
@@ -1,0 +1,40 @@
+package com.ncp.moeego.pro.controller;
+
+import com.ncp.moeego.member.service.impl.MemberServiceImpl;
+import com.ncp.moeego.pro.dto.ProJoinRequest;
+import com.ncp.moeego.pro.service.ProServiceImpl;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/pro")
+public class ProController {
+
+    private final ProServiceImpl proService;
+    private final MemberServiceImpl memberService;
+
+    public ProController(ProServiceImpl proService, MemberServiceImpl memberService) {
+        this.proService = proService;
+        this.memberService = memberService;
+    }
+
+    @PostMapping("/join")
+    public ResponseEntity<String> proJoin(@RequestBody ProJoinRequest proJoinRequest) {
+        String response = proService.proJoin(proJoinRequest);
+
+        return switch (response) {
+            case "pro join success" -> ResponseEntity.status(HttpStatus.OK).body(response);
+            case "join fail", "pro apply fail" -> ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+            default -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("internal server error");
+        };
+    }
+
+    @PostMapping("/join/exist")
+    public boolean isExistingEmail(@RequestParam String email) {
+        return memberService.isExist(email);
+
+    }
+
+
+}

--- a/src/main/java/com/ncp/moeego/pro/dto/ProApplyRequest.java
+++ b/src/main/java/com/ncp/moeego/pro/dto/ProApplyRequest.java
@@ -1,0 +1,27 @@
+package com.ncp.moeego.pro.dto;
+
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+public class ProApplyRequest {
+
+    private Long memberNo;
+    private Long mainCateNo;
+    private Long subCateNo;
+    private String oneIntro;
+    private String intro;
+    private Date depriveDate;
+
+    public ProApplyRequest() {
+    }
+
+    public ProApplyRequest(ProJoinRequest request) {
+        this.mainCateNo = request.getMainCateNo();
+        this.subCateNo = request.getSubCateNo();
+        this.oneIntro = request.getOneIntro();
+        this.intro = request.getIntro();
+    }
+
+}

--- a/src/main/java/com/ncp/moeego/pro/dto/ProJoinRequest.java
+++ b/src/main/java/com/ncp/moeego/pro/dto/ProJoinRequest.java
@@ -1,0 +1,20 @@
+package com.ncp.moeego.pro.dto;
+
+import lombok.Data;
+
+@Data
+public class ProJoinRequest {
+
+    private Long mainCateNo;
+    private Long subCateNo;
+    private String oneIntro;
+    private String intro;
+
+    private String email;
+    private String name;
+    private String pwd;
+    private Integer gender;
+    private String phone;
+    private String address;
+
+}

--- a/src/main/java/com/ncp/moeego/pro/repository/ProRepository.java
+++ b/src/main/java/com/ncp/moeego/pro/repository/ProRepository.java
@@ -1,0 +1,10 @@
+package com.ncp.moeego.pro.repository;
+
+import com.ncp.moeego.pro.bean.Pro;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProRepository extends JpaRepository<Pro, Long> {
+
+}

--- a/src/main/java/com/ncp/moeego/pro/service/ProService.java
+++ b/src/main/java/com/ncp/moeego/pro/service/ProService.java
@@ -1,0 +1,10 @@
+package com.ncp.moeego.pro.service;
+
+import com.ncp.moeego.pro.dto.ProApplyRequest;
+import com.ncp.moeego.pro.dto.ProJoinRequest;
+
+public interface ProService {
+    String proJoin(ProJoinRequest request);
+    String proApply(ProApplyRequest request);
+
+}

--- a/src/main/java/com/ncp/moeego/pro/service/ProServiceImpl.java
+++ b/src/main/java/com/ncp/moeego/pro/service/ProServiceImpl.java
@@ -1,0 +1,66 @@
+package com.ncp.moeego.pro.service;
+
+import com.ncp.moeego.category.repository.MainCategoryRepository;
+import com.ncp.moeego.category.repository.SubCategoryRepository;
+import com.ncp.moeego.member.bean.JoinDTO;
+import com.ncp.moeego.member.entity.MemberStatus;
+import com.ncp.moeego.member.service.impl.MemberServiceImpl;
+import com.ncp.moeego.pro.bean.Pro;
+import com.ncp.moeego.pro.dto.ProApplyRequest;
+import com.ncp.moeego.pro.dto.ProJoinRequest;
+import com.ncp.moeego.pro.repository.ProRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+public class ProServiceImpl implements ProService {
+
+    private final MemberServiceImpl memberService;
+    private final ProRepository proRepository;
+    private final MainCategoryRepository mainCategoryRepository;
+    private final SubCategoryRepository subCategoryRepository;
+
+    public ProServiceImpl(MemberServiceImpl memberService, ProRepository proRepository, MainCategoryRepository mainCategoryRepository, SubCategoryRepository subCategoryRepository) {
+        this.memberService = memberService;
+        this.proRepository = proRepository;
+        this.mainCategoryRepository = mainCategoryRepository;
+        this.subCategoryRepository = subCategoryRepository;
+    }
+
+    @Transactional
+    @Override
+    public String proJoin(ProJoinRequest proJoinRequest) {
+        JoinDTO join = new JoinDTO(proJoinRequest);
+        log.info(join.toString());
+
+        if (!memberService.write(join)) {
+            return "join fail";
+
+        }
+
+        ProApplyRequest proApplyRequest = new ProApplyRequest(proJoinRequest);
+        proApplyRequest.setMemberNo(memberService.getMemberNo(proJoinRequest.getEmail()));
+
+        String applyResponse = proApply(proApplyRequest);
+        if (applyResponse.equals("pro apply success")) {
+            return "pro join success";
+        }
+        return "pro apply fail";
+    }
+
+    @Override
+    public String proApply(ProApplyRequest request) {
+        Pro pro = new Pro();
+        pro.setMainCateNo(mainCategoryRepository.findById(request.getMainCateNo()).orElseThrow(() -> new IllegalArgumentException("Invalid MainCateNo")));
+        pro.setSubCateNo(subCategoryRepository.findById(request.getSubCateNo()).orElseThrow(() -> new IllegalArgumentException("Invalid SubCateNo")));
+        pro.setOneIntro(request.getOneIntro());
+        pro.setIntro(request.getIntro());
+        proRepository.save(pro);
+        memberService.setMemberStatus(request.getMemberNo(), MemberStatus.ROLE_PEND_PRO);
+
+        return "pro apply success";
+    }
+
+}

--- a/src/main/java/com/ncp/moeego/pro/service/ProServiceImpl.java
+++ b/src/main/java/com/ncp/moeego/pro/service/ProServiceImpl.java
@@ -9,9 +9,13 @@ import com.ncp.moeego.pro.bean.Pro;
 import com.ncp.moeego.pro.dto.ProApplyRequest;
 import com.ncp.moeego.pro.dto.ProJoinRequest;
 import com.ncp.moeego.pro.repository.ProRepository;
+import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.swing.text.html.parser.Entity;
 
 @Service
 @Slf4j
@@ -53,6 +57,7 @@ public class ProServiceImpl implements ProService {
     @Override
     public String proApply(ProApplyRequest request) {
         Pro pro = new Pro();
+        pro.setMember(memberService.getMemberById(request.getMemberNo()));
         pro.setMainCateNo(mainCategoryRepository.findById(request.getMainCateNo()).orElseThrow(() -> new IllegalArgumentException("Invalid MainCateNo")));
         pro.setSubCateNo(subCategoryRepository.findById(request.getSubCateNo()).orElseThrow(() -> new IllegalArgumentException("Invalid SubCateNo")));
         pro.setOneIntro(request.getOneIntro());


### PR DESCRIPTION
# 구현한 기능
- 달인 회원가입 구현

# 상세내용 
- proJoin(달인회원가입) 과 proApply(달인 권한 신청) 메서드 작성
- /pro/join  으로 post 요청이 오면 먼저 일반회원으로 가입 후 달인권한신청까지 자동으로 되게 구현
- MemberServiceImpl에서 email 중복 확인 로직 분리 후 컨트롤러에도 추가
- Pro엔티티의 reserveNo를 nullable로 변경
- ProController 에서 HttpStatus로 예외처리
- 포스트맨으로 확인 완료

# TODO
- 카테고리 레포지토리 사용하는 로직을 카테고리 서비스로 분리
- 예외처리 보강

