### PR TITLE
[BE] Feat: 관리자 대시보드 차트 데이터화 로직 구현

### DIFF
--- a/src/main/java/com/ncp/moeego/member/controller/AdminController.java
+++ b/src/main/java/com/ncp/moeego/member/controller/AdminController.java
@@ -1,6 +1,8 @@
 package com.ncp.moeego.member.controller;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +17,7 @@ import com.ncp.moeego.member.entity.Member;
 import com.ncp.moeego.member.bean.MemberSummaryDTO;
 
 import com.ncp.moeego.member.service.AdminService;
+import com.ncp.moeego.pro.entity.Pro;
 
 import lombok.RequiredArgsConstructor;
 
@@ -53,11 +56,33 @@ public class AdminController {
     
     
     
-    //회원가입, 고수 , 탈퇴 일주일 치 데이터화 ( 관리자 페이지 차트 데이터화 활용 )
-//    @GetMapping("/admin/member-status")
-//    public ResponseEntity<Map<String, List<MemberStatsDTO>>> getMemberStats(){
-//    	
-//    }
+    //회원가입 일주일 치 데이터화 ( 관리자 페이지 차트 데이터화 활용 )
+    @GetMapping("/admin/weekmember")
+    public ResponseEntity<List<Map<String , Object>>> getWeekMemberData(){
+    	List<Map<String , Object>> weekmemberData = adminService.getWeekMemberData();
+    	return ResponseEntity.ok(weekmemberData);
+    }
+    
+    //고수 등록 일주일 치 데이터화 ( 관리자 페이지 차트 데이터화 활용 )
+    @GetMapping("/admin/weekpro")
+    public ResponseEntity<List<Map<String, Object>>> getProMemberJoinData() {
+    	LocalDateTime startDateTime = LocalDateTime.now().minusDays(7).withHour(0).withMinute(0).withSecond(0).withNano(0);  // 일주일 전 자정
+        LocalDateTime endDateTime = LocalDateTime.now().withHour(23).withMinute(59).withSecond(59).withNano(999999999);  // 오늘 자정
+
+        List<Map<String, Object>> result = adminService.getProMemberJoinData(startDateTime, endDateTime);
+        return ResponseEntity.ok(result);
+    }
+    
+    // 탈퇴 회원 일주일 치 데이터화 ( 관리자 페이지 차트 데이터화 활용 )
+    @GetMapping("/admin/weekleave")
+    public ResponseEntity<List<Map<String, Object>>> getCancelledMembersData() {
+        // 예시로 현재 날짜와 일주일 전 날짜를 사용하여 데이터를 조회한다고 가정
+        LocalDateTime startDateTime = LocalDateTime.now().minusDays(7).withHour(0).withMinute(0).withSecond(0).withNano(0);  // 일주일 전 자정
+        LocalDateTime endDateTime = LocalDateTime.now().withHour(23).withMinute(59).withSecond(59).withNano(999999999);  // 오늘 자정
+
+        List<Map<String, Object>> result = adminService.getCancelledMemberData(startDateTime, endDateTime);
+        return ResponseEntity.ok(result);
+    }
     
     
     
@@ -91,6 +116,8 @@ public class AdminController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("취소 실패");
         }
     }
+    
+    
     
     
 }

--- a/src/main/java/com/ncp/moeego/member/repository/MemberRepository.java
+++ b/src/main/java/com/ncp/moeego/member/repository/MemberRepository.java
@@ -1,15 +1,19 @@
 package com.ncp.moeego.member.repository;
 
+import com.ncp.moeego.cancel.bean.Cancel;
 import com.ncp.moeego.member.bean.MemberSummaryDTO;
 import com.ncp.moeego.member.entity.Member;
 import com.ncp.moeego.member.entity.MemberStatus;
+import com.ncp.moeego.pro.entity.Pro;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -35,8 +39,16 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             "GROUP BY m.memberNo, m.name, m.memberStatus, p.oneIntro")
     List<MemberSummaryDTO> findMemberSummaryByStatus(@Param("status") MemberStatus status);
     
-    
-    
+    // 일주일 치 회원 가입 수
+    List<Member> findByJoinDateBetween(LocalDateTime startDate, LocalDateTime endDate);
+
+    // 일주일 간 고수 등록 수
+    @Query("SELECT p FROM Pro p WHERE p.accessDate BETWEEN :startDate AND :endDate")
+    List<Pro> findProMembersByJoinDate(@Param("startDate") LocalDateTime startDateTime, @Param("endDate") LocalDateTime endDateTime);
+
+    // 일주일 간 탈퇴 회원 수
+    @Query("SELECT p FROM Cancel p WHERE p.cancelDate BETWEEN :startDate AND :endDate")
+    List<Cancel> findByCancelDateBetween(@Param("startDate") LocalDateTime startDateTime, @Param("endDate") LocalDateTime endDateTime);
 
 
     

--- a/src/main/java/com/ncp/moeego/member/service/AdminService.java
+++ b/src/main/java/com/ncp/moeego/member/service/AdminService.java
@@ -1,9 +1,12 @@
 package com.ncp.moeego.member.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import com.ncp.moeego.member.bean.MemberSummaryDTO;
 import com.ncp.moeego.member.bean.oauth2.MemberDTO;
+import com.ncp.moeego.pro.entity.Pro;
 
 
 public interface AdminService {
@@ -19,5 +22,12 @@ public interface AdminService {
 	boolean approveMember(Long id);
 
 	boolean cancelMember(Long id);
+
+	List<Map<String, Object>> getWeekMemberData();
+
+
+	List<Map<String, Object>> getProMemberJoinData(LocalDateTime startDateTime, LocalDateTime endDateTime);
+
+	List<Map<String, Object>> getCancelledMemberData(LocalDateTime startDateTime, LocalDateTime endDateTime);
 	
 }

--- a/src/main/java/com/ncp/moeego/member/service/impl/AdminServiceImpl.java
+++ b/src/main/java/com/ncp/moeego/member/service/impl/AdminServiceImpl.java
@@ -1,15 +1,23 @@
 package com.ncp.moeego.member.service.impl;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import com.ncp.moeego.cancel.bean.Cancel;
 import com.ncp.moeego.member.bean.MemberSummaryDTO;
 import com.ncp.moeego.member.bean.oauth2.MemberDTO;
 import com.ncp.moeego.member.entity.Member;
 import com.ncp.moeego.member.entity.MemberStatus;
 import com.ncp.moeego.member.repository.MemberRepository;
 import com.ncp.moeego.member.service.AdminService;
+import com.ncp.moeego.pro.entity.Pro;
+import com.ncp.moeego.pro.repository.ProRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class AdminServiceImpl implements AdminService {
 
     private final MemberRepository memberRepository;
+    private final ProRepository proRepository;
 
     @Override
     public int getRoleUserCount() {
@@ -41,13 +50,26 @@ public class AdminServiceImpl implements AdminService {
 
 	@Override
 	public boolean approveMember(Long member_no) {
-		Member member = memberRepository.findById(member_no).orElse(null);
-        if (member != null && member.getMemberStatus() == MemberStatus.ROLE_PEND_PRO) {
-            member.setMemberStatus(MemberStatus.ROLE_PRO);
-            memberRepository.save(member);
-            return true;
-        }
-        return false;
+	    Member member = memberRepository.findById(member_no).orElse(null);
+	    if (member != null && member.getMemberStatus() == MemberStatus.ROLE_PEND_PRO) {
+	        member.setMemberStatus(MemberStatus.ROLE_PRO);  // 멤버 상태 변경
+	        memberRepository.save(member);  // 변경된 멤버 저장
+
+	        // Pro 엔티티의 accessDate 값도 오늘 날짜로 설정
+	        Pro pro = proRepository.findByMember(member);  // 해당 멤버의 Pro 객체 찾기
+	        if (pro != null) {
+	            // 원하는 포맷 (예: "2024-12-06 14:28:25")
+	            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+	            String formattedDate = LocalDateTime.now().format(formatter);  // 현재 시간 포맷팅
+	            LocalDateTime accessDate = LocalDateTime.parse(formattedDate, formatter);  // 다시 LocalDateTime으로 변환
+
+	            pro.setAccessDate(accessDate);  // accessDate를 포맷된 날짜로 설정
+	            proRepository.save(pro);  // Pro 엔티티 저장
+	        }
+
+	        return true;
+	    }
+	    return false;
 	}
 	
 	@Override
@@ -61,7 +83,74 @@ public class AdminServiceImpl implements AdminService {
 	    return false;
 	}
 
-	
+	@Override
+	public List<Map<String, Object>> getWeekMemberData() {
+		LocalDate today = LocalDate.now();
+        LocalDate weekAgo = today.minusDays(7);
+
+        LocalDateTime startDateTime = weekAgo.atStartOfDay();  // 일주일 전 자정
+        LocalDateTime endDateTime = today.atStartOfDay().plusDays(1).minusNanos(1);
+        
+        // 회원 가입 데이터 조회 (가입 날짜가 일주일 이내인 회원들)
+        List<Member> members = memberRepository.findByJoinDateBetween(startDateTime, endDateTime);
+
+        // 날짜별로 가입 수 집계
+        return members.stream()
+                .collect(Collectors.groupingBy(member -> member.getJoinDate().toLocalDate()))
+                .entrySet()
+                .stream()
+                .map(entry -> {
+                    Map<String, Object> result = Map.of(
+                        "date", entry.getKey().format(DateTimeFormatter.ISO_DATE),
+                        "count", entry.getValue().size()
+                    );
+                    return result;
+                })
+                .collect(Collectors.toList());
+	}
+
+	@Override
+	public List<Map<String, Object>> getProMemberJoinData(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+	    List<Pro> proMembers = memberRepository.findProMembersByJoinDate(startDateTime, endDateTime);
+
+	    return proMembers.stream()
+	        .collect(Collectors.groupingBy(
+	            member -> member.getAccessDate().toLocalDate(), // 날짜별로 그룹핑
+	            Collectors.counting() // 각 날짜별 개수 계산
+	        ))
+	        .entrySet()
+	        .stream()
+	        .map(entry -> {
+	            Map<String, Object> result = Map.of(
+	                "date", entry.getKey().format(DateTimeFormatter.ISO_DATE),  // yyyy-MM-dd 형식으로 변환
+	                "count", entry.getValue()
+	            );
+	            return result;
+	        })
+	        .collect(Collectors.toList());
+	}
+
+	public List<Map<String, Object>> getCancelledMemberData(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        // 날짜 범위에 해당하는 탈퇴한 멤버 조회
+        List<Cancel> cancelledMembers = memberRepository.findByCancelDateBetween(startDateTime, endDateTime);
+
+        // 날짜별로 탈퇴한 멤버 수 집계
+        return cancelledMembers.stream()
+            .collect(Collectors.groupingBy(
+                cancel -> cancel.getCancelDate().toLocalDate(), // 날짜별로 그룹핑
+                Collectors.counting() // 각 날짜별 개수 계산
+            ))
+            .entrySet()
+            .stream()
+            .map(entry -> {
+                Map<String, Object> result = Map.of(
+                    "date", entry.getKey().format(DateTimeFormatter.ISO_DATE),  // yyyy-MM-dd 형식으로 변환
+                    "count", entry.getValue()
+                );
+                return result;
+            })
+            .collect(Collectors.toList());
+    }
 	
 	
 	

--- a/src/main/java/com/ncp/moeego/pro/repository/ProRepository.java
+++ b/src/main/java/com/ncp/moeego/pro/repository/ProRepository.java
@@ -1,5 +1,6 @@
 package com.ncp.moeego.pro.repository;
 
+import com.ncp.moeego.member.entity.Member;
 import com.ncp.moeego.pro.dto.FavoriteResponse;
 import com.ncp.moeego.pro.entity.Pro;
 import org.springframework.data.domain.Page;
@@ -26,5 +27,7 @@ public interface ProRepository extends JpaRepository<Pro, Long> {
                     """
     )
     Page<FavoriteResponse> findByProNoIn(@Param("proNo") List<Long> proNo, Pageable pageable);
+
+	Pro findByMember(Member member);
 
 }


### PR DESCRIPTION
[BE] Feat: 관리자 대시보드 차트 데이터화 로직 구현
- 일주일 데이터
회원 가입 수
고수 등록 수 
탈퇴 회원 수 

- 고수 승인 요청 시
상태 값 변경 및 현재 시각으로 access_date값 update