### PR TITLE
[BE] Ref: 관리자 페이지 고수 관리 로직 수정

### DIFF
--- a/src/main/java/com/ncp/moeego/member/bean/MemberSummaryDTO.java
+++ b/src/main/java/com/ncp/moeego/member/bean/MemberSummaryDTO.java
@@ -10,16 +10,18 @@ public class MemberSummaryDTO {
     private String name; // 이름
     private MemberStatus memberStatus; 
     private String oneIntro;
-    private Long count;
+    private String intro;
+    private String cate_name;
     
     
     
-    public MemberSummaryDTO(Long memberNo, String name, MemberStatus memberStatus, String oneIntro, Long count) {
+    public MemberSummaryDTO(Long memberNo, String name, MemberStatus memberStatus, String oneIntro, String intro, String cate_name) {
         this.memberNo = memberNo;
         this.name = name;
         this.memberStatus = memberStatus;
         this.oneIntro = oneIntro;
-        this.count = count;
+        this.intro = intro;
+        this.cate_name = cate_name;
     }
 
 }

--- a/src/main/java/com/ncp/moeego/member/bean/ProDTO.java
+++ b/src/main/java/com/ncp/moeego/member/bean/ProDTO.java
@@ -1,6 +1,9 @@
 package com.ncp.moeego.member.bean;
 
 import java.time.LocalDateTime;
+
+import com.ncp.moeego.member.entity.MemberStatus;
+
 import lombok.Data;
 
 @Data
@@ -9,24 +12,24 @@ public class ProDTO {
     private String name;
     private LocalDateTime accessDate;
     private float star;
-    private LocalDateTime depriveDate;
     private Long proNo;
     private String mainCateName;
     private String oneIntro; // 한줄소개 추가
     private String intro;    // 서비스 소개 추가
+    private MemberStatus memberStatus;
 
-    // 생성자 업데이트
+    // 생성자 업데이트 (status 제거)
     public ProDTO(Long memberNo, String name, LocalDateTime accessDate, float star, 
-                  LocalDateTime depriveDate, Long proNo, String mainCateName, 
-                  String oneIntro, String intro) {
+                  Long proNo, String mainCateName, 
+                  String oneIntro, String intro, MemberStatus memberStatus) {
         this.memberNo = memberNo;
         this.name = name;
         this.accessDate = accessDate;
         this.star = star;
-        this.depriveDate = depriveDate;
         this.proNo = proNo;
         this.mainCateName = mainCateName;
         this.oneIntro = oneIntro;
         this.intro = intro;
+        this.memberStatus = memberStatus;
     }
 }

--- a/src/main/java/com/ncp/moeego/member/controller/AdminController.java
+++ b/src/main/java/com/ncp/moeego/member/controller/AdminController.java
@@ -90,7 +90,7 @@ public class AdminController {
     //고수 권한 페이지
     @GetMapping("/admin/pro/approval")
     public ResponseEntity<List<MemberSummaryDTO>> proApproval() {
-        List<MemberSummaryDTO> pendingProMembers = adminService.getPendingProMembers();
+        List<MemberSummaryDTO> pendingProMembers = adminService.getPendingProMembers(MemberStatus.ROLE_PEND_PRO);
         return ResponseEntity.ok(pendingProMembers);
     }
     
@@ -116,6 +116,19 @@ public class AdminController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("취소 실패");
         }
     }
+    
+    
+    // 고수 박탈 버튼 클릭시
+    @PostMapping("/admin/member/pro/cancel/{memberNo}")
+    public ResponseEntity<String> revokePro(@PathVariable("memberNo") Long memberNo) {
+        try {
+            adminService.revokeMember(memberNo);  // 서비스에서 박탈 처리
+            return ResponseEntity.ok("박탈 처리 완료");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("박탈 처리 오류");
+        }
+    }
+    
     
     // 일반 회원 조회
     @GetMapping("/admin/member/user")

--- a/src/main/java/com/ncp/moeego/member/service/AdminService.java
+++ b/src/main/java/com/ncp/moeego/member/service/AdminService.java
@@ -21,7 +21,7 @@ public interface AdminService {
 
 	int getRoleProCount();
 
-	List<MemberSummaryDTO> getPendingProMembers();
+	List<MemberSummaryDTO> getPendingProMembers(MemberStatus rolePendPro);
 
 	boolean approveMember(Long id);
 
@@ -40,6 +40,8 @@ public interface AdminService {
 	List<ProDTO> getProMembersWithDetails();
 
 	List<CancelDTO> getCancelMembersWithDetails();
+
+	void revokeMember(Long memberNo);
 
 	
 

--- a/src/main/java/com/ncp/moeego/member/service/impl/AdminServiceImpl.java
+++ b/src/main/java/com/ncp/moeego/member/service/impl/AdminServiceImpl.java
@@ -3,12 +3,14 @@ package com.ncp.moeego.member.service.impl;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ncp.moeego.member.bean.CancelDTO;
 import com.ncp.moeego.cancel.entity.Cancel;
@@ -19,7 +21,10 @@ import com.ncp.moeego.member.entity.Member;
 import com.ncp.moeego.member.entity.MemberStatus;
 import com.ncp.moeego.member.repository.MemberRepository;
 import com.ncp.moeego.member.service.AdminService;
+import com.ncp.moeego.pro.entity.ItemStatus;
 import com.ncp.moeego.pro.entity.Pro;
+import com.ncp.moeego.pro.entity.ProItem;
+import com.ncp.moeego.pro.repository.ProItemRepository;
 import com.ncp.moeego.pro.repository.ProRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -30,6 +35,7 @@ public class AdminServiceImpl implements AdminService {
 
     private final MemberRepository memberRepository;
     private final ProRepository proRepository;
+    private final ProItemRepository proItemRepository;
 
     @Override
     public int getRoleUserCount() {
@@ -47,27 +53,32 @@ public class AdminServiceImpl implements AdminService {
 	}
 
 	@Override
-	public List<MemberSummaryDTO> getPendingProMembers() {
-        return memberRepository.findMemberSummaryByStatus(MemberStatus.ROLE_PEND_PRO);
-    }
+	public List<MemberSummaryDTO> getPendingProMembers(MemberStatus status) {
+	    return memberRepository.findMemberSummaryByStatus(status);
+	}
 
 	@Override
 	public boolean approveMember(Long member_no) {
+	    // 1. Member 테이블에서 멤버 조회
 	    Member member = memberRepository.findById(member_no).orElse(null);
 	    if (member != null && member.getMemberStatus() == MemberStatus.ROLE_PEND_PRO) {
-	        member.setMemberStatus(MemberStatus.ROLE_PRO);  // 멤버 상태 변경
+	        
+	        // 2. Member 테이블에서 상태를 ROLE_PRO로 변경
+	        member.setMemberStatus(MemberStatus.ROLE_PRO);
 	        memberRepository.save(member);  // 변경된 멤버 저장
 
-	        // Pro 엔티티의 accessDate 값도 오늘 날짜로 설정
+	        // 3. Pro 엔티티의 accessDate 값도 현재 날짜로 설정
 	        Pro pro = proRepository.findByMember(member);  // 해당 멤버의 Pro 객체 찾기
 	        if (pro != null) {
-	            // 원하는 포맷 (예: "2024-12-06 14:28:25")
-	            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-	            String formattedDate = LocalDateTime.now().format(formatter);  // 현재 시간 포맷팅
-	            LocalDateTime accessDate = LocalDateTime.parse(formattedDate, formatter);  // 다시 LocalDateTime으로 변환
-
-	            pro.setAccessDate(accessDate);  // accessDate를 포맷된 날짜로 설정
+	            pro.setAccessDate(LocalDateTime.now());  // accessDate를 현재 날짜로 설정
 	            proRepository.save(pro);  // Pro 엔티티 저장
+	        }
+
+	        // 4. ProItem 테이블에서 상태를 ACTIVE로 변경
+	        List<ProItem> proItems = proItemRepository.findByPro(pro);  // 해당 Pro에 관련된 모든 ProItem 찾기
+	        for (ProItem proItem : proItems) {
+	            proItem.setItemStatus(ItemStatus.ACTIVE);  // 상태를 ACTIVE로 설정
+	            proItemRepository.save(proItem);  // ProItem 상태 저장
 	        }
 
 	        return true;
@@ -76,15 +87,35 @@ public class AdminServiceImpl implements AdminService {
 	}
 	
 	@Override
-	public boolean cancelMember(Long member_no) {
-	    Member member = memberRepository.findById(member_no).orElse(null);
-	    if (member != null && member.getMemberStatus() == MemberStatus.ROLE_PEND_PRO) {
-	        member.setMemberStatus(MemberStatus.ROLE_USER);  // 예: ROLE_USER로 변경
-	        memberRepository.save(member);
-	        return true;
+	public boolean cancelMember(Long memberNo) {
+	    // Member 객체 가져오기
+	    Member member = memberRepository.findById(memberNo).orElse(null);
+
+	    if (member == null) {
+	        return false; // Member가 없으면 취소 실패
 	    }
-	    return false;
+
+	    // Pro 조회 (Member와 연결된 Pro 데이터)
+	    Pro pro = proRepository.findByMember_MemberNo(memberNo);
+
+	    if (pro != null) {
+	        // ProItem 삭제 (Pro와 연결된 모든 ProItem 삭제)
+	        List<ProItem> proItems = proItemRepository.findByPro_ProNo(pro.getProNo());
+	        if (!proItems.isEmpty()) {
+	            proItemRepository.deleteAll(proItems);
+	        }
+
+	        // Pro 삭제
+	        proRepository.delete(pro);
+	    }
+
+	    // Member 상태 변경
+	    member.setMemberStatus(MemberStatus.ROLE_USER); // 상태 변경
+	    memberRepository.save(member); // Member 상태 변경 후 저장
+
+	    return true; // 작업 성공
 	}
+
 
 	@Override
 	public List<Map<String, Object>> getWeekMemberData() {
@@ -154,6 +185,30 @@ public class AdminServiceImpl implements AdminService {
             })
             .collect(Collectors.toList());
     }
+
+	// 박탈 버튼 클릭시
+	@Override
+	public void revokeMember(Long memberNo) {
+	    // 1. 회원 정보 조회
+	    Member member = memberRepository.findById(memberNo)
+	        .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+	    
+	    // 2. member_status를 'ROLE_CANCEL_PRO'로 변경
+	    member.setMemberStatus(MemberStatus.ROLE_CANCEL_PRO);
+	    memberRepository.save(member);
+
+	    // 3. pro 테이블에서 해당 member_no에 연관된 pro 조회
+	    Pro pro = proRepository.findByMemberMemberNo(memberNo)
+	        .orElseThrow(() -> new IllegalArgumentException("프로 회원 정보가 존재하지 않습니다."));
+
+	    // 4. pro_item 테이블에서 해당 pro_no에 연관된 모든 pro_item 삭제
+	    List<ProItem> proItems = proItemRepository.findByPro(pro);  // pro와 연관된 pro_items 조회
+	    proItemRepository.deleteAll(proItems);  // 연관된 pro_item 삭제
+
+	    // 5. pro 테이블에서 해당 member_no에 연관된 pro 삭제
+	    proRepository.delete(pro);  // pro 삭제
+	}
+
 	
 	// 일반 회원 조회
     public List<Member> getUserMembers() {
@@ -162,7 +217,7 @@ public class AdminServiceImpl implements AdminService {
 
     // 고수 회원 조회
     public List<ProDTO> getProMembersWithDetails() {
-        return memberRepository.findProMembersWithDetails();
+        return memberRepository.findProMembersWithRolePro();
     }
 
     // 탈퇴 회원 조회
@@ -170,7 +225,6 @@ public class AdminServiceImpl implements AdminService {
 	public List<CancelDTO> getCancelMembersWithDetails() {
         return memberRepository.findAllCancelDetails();
     }
-
 
 	
 }

--- a/src/main/java/com/ncp/moeego/pro/repository/ProItemRepository.java
+++ b/src/main/java/com/ncp/moeego/pro/repository/ProItemRepository.java
@@ -3,7 +3,11 @@ package com.ncp.moeego.pro.repository;
 import com.ncp.moeego.category.entity.SubCategory;
 import com.ncp.moeego.pro.dto.ItemResponse;
 import com.ncp.moeego.pro.entity.ItemStatus;
+import com.ncp.moeego.pro.entity.Pro;
 import com.ncp.moeego.pro.entity.ProItem;
+
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,4 +29,11 @@ public interface ProItemRepository extends JpaRepository<ProItem, Long> {
     ItemResponse getItemDetails(@Param("proItemNo") Long proItemNo);
 
     boolean existsByProItemNoAndItemStatus(Long proItemNo, ItemStatus itemStatus);
+    
+    // 해당 Pro에 속하는 ProItem 조회 (admin에서 사용)
+    List<ProItem> findByPro(Pro pro);  
+    
+    List<ProItem> findByPro_Member_MemberNo(Long memberNo);
+
+	List<ProItem> findByPro_ProNo(Long proNo);
 }

--- a/src/main/java/com/ncp/moeego/pro/repository/ProRepository.java
+++ b/src/main/java/com/ncp/moeego/pro/repository/ProRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ProRepository extends JpaRepository<Pro, Long> {
@@ -29,5 +30,9 @@ public interface ProRepository extends JpaRepository<Pro, Long> {
     Page<FavoriteResponse> findByProNoIn(@Param("proNo") List<Long> proNo, Pageable pageable);
 
 	Pro findByMember(Member member);
+
+	Optional<Pro> findByMemberMemberNo(Long memberNo);
+
+	Pro findByMember_MemberNo(Long memberNo);
 
 }

--- a/src/main/java/com/ncp/moeego/pro/service/ProService.java
+++ b/src/main/java/com/ncp/moeego/pro/service/ProService.java
@@ -21,5 +21,5 @@ public interface ProService {
 
     Map<String, Object> getInitItem(Long memberNo);
 
-    Map<String, Object> getItemList(Long subCateNo, String location, int pg);
+    //Map<String, Object> getItemList(Long subCateNo, String location, int pg);
 }


### PR DESCRIPTION
[BE] Ref: 관리자 페이지 고수 관리 로직 수정

고수 권한 승인 시
- member 테이블의 member_status = ROLE_PRO 변경
- pro_item 테이블의 status = ACTIVE 변경

고수 권한 취소 시
- member 테이블의 member_status = ROLE_USER 변경
- pro 테이블의 관련 데이터 삭제
- pro_item 테이블의 관련 데이터 삭제

박탈 버튼 클릭 시
- 해당 번호 pro 테이블 삭제
- 해당 번호 pro_item 테이블 삭제
- 해당 번호 member 테이블의 member_status = ROLE_CANCEL_PRO 변경
