### PR TITLE
[BE] Feat:  달인 상세보기 페이지에 리뷰 반환

### DIFF
--- a/src/main/java/com/ncp/moeego/image/entity/Image.java
+++ b/src/main/java/com/ncp/moeego/image/entity/Image.java
@@ -1,48 +1,40 @@
 package com.ncp.moeego.image.entity;
 
 import com.ncp.moeego.article.entity.Article;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import lombok.Data;
 import com.ncp.moeego.member.entity.Member;
 import com.ncp.moeego.pro.entity.ProItem;
 import com.ncp.moeego.review.entity.Review;
+import jakarta.persistence.*;
+import lombok.Data;
 
 @Entity
 @Data
 public class Image {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "image_no")
-	private Long imageNo;
-	
-	@ManyToOne // 여러개의 이미지를 한 리뷰에 넣을수있음
-	@JoinColumn(name="review_no")
-	private Review review;
-	
-	@ManyToOne // 여러개의 이미지를 고수 게시판에 넣을수있음
-	@JoinColumn(name="pro_item_no", nullable = true)
-	private ProItem proItem;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_no")
+    private Long imageNo;
 
-	@ManyToOne // 여러개의 이미지를 게시판에 넣을수있음
-	@JoinColumn(name="article_no", nullable = true)
-	private Article article;
-	
-	@ManyToOne // 여러개의 이미지를 사용자가 넣을수있음
-	@JoinColumn(name="member_no", nullable = false)
-	private Member member;
-	
-	@Column(length = 3000)
-	private String imageName;
-	
-	@Column(length = 3000)
-	private String imageUuidName;
-	
-	
-	
+    @ManyToOne // 여러개의 이미지를 한 리뷰에 넣을수있음
+    @JoinColumn(name = "review_no")
+    private Review review;
+
+    @ManyToOne // 여러개의 이미지를 고수 게시판에 넣을수있음
+    @JoinColumn(name = "pro_item_no", nullable = true)
+    private ProItem proItem;
+
+    @ManyToOne // 여러개의 이미지를 게시판에 넣을수있음
+    @JoinColumn(name = "article_no", nullable = true)
+    private Article article;
+
+    @ManyToOne // 여러개의 이미지를 사용자가 넣을수있음
+    @JoinColumn(name = "member_no", nullable = false)
+    private Member member;
+
+    @Column(length = 3000)
+    private String imageName;
+
+    @Column(length = 3000)
+    private String imageUuidName;
+
 }

--- a/src/main/java/com/ncp/moeego/image/repository/ImageRepository.java
+++ b/src/main/java/com/ncp/moeego/image/repository/ImageRepository.java
@@ -1,6 +1,7 @@
 package com.ncp.moeego.image.repository;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,7 +18,7 @@ import com.ncp.moeego.review.entity.Review;
 import jakarta.transaction.Transactional;
 
 @Repository
-public interface ImageRepository extends JpaRepository<Image, Long>{
+public interface ImageRepository extends JpaRepository<Image, Long> {
 
 	List<Image> findByArticle_ArticleNo(Long articleNo);
 
@@ -28,7 +29,7 @@ public interface ImageRepository extends JpaRepository<Image, Long>{
 	void deleteByImageUuidName(@Param("profileImage") String profileImage);
 
 	// uuid값 가져오기
-	
+
 	// 게시글 번호 기준으로 이미지 리스트 조회
 	List<Image> findByArticle(Article article);
 
@@ -42,5 +43,8 @@ public interface ImageRepository extends JpaRepository<Image, Long>{
 
 	// 리뷰 번호에 맞는 이미지 조회
 	List<Image> findByReview(Review review);
+
+	@Query("select i.review.reviewNo, i.imageUuidName From Image i where i.review.reviewNo IN :reviewNos")
+	List<Object[]> findImageUuidsByReviewNos(@Param("reviewNos") List<Long> reviewNos);
 
 }

--- a/src/main/java/com/ncp/moeego/pro/controller/ProController.java
+++ b/src/main/java/com/ncp/moeego/pro/controller/ProController.java
@@ -4,6 +4,9 @@ import com.ncp.moeego.common.ApiResponse;
 import com.ncp.moeego.member.service.impl.MemberServiceImpl;
 import com.ncp.moeego.pro.dto.*;
 import com.ncp.moeego.pro.service.ProServiceImpl;
+import com.ncp.moeego.review.bean.ItemReviewResponse;
+import com.ncp.moeego.review.service.ReviewService;
+import com.ncp.moeego.review.service.ReviewServiceImpl;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -20,10 +23,14 @@ public class ProController {
 
     private final ProServiceImpl proService;
     private final MemberServiceImpl memberService;
+    private final ReviewService reviewService;
+    private final ReviewServiceImpl reviewServiceImpl;
 
-    public ProController(ProServiceImpl proService, MemberServiceImpl memberService) {
+    public ProController(ProServiceImpl proService, MemberServiceImpl memberService, ReviewService reviewService, ReviewServiceImpl reviewServiceImpl) {
         this.proService = proService;
         this.memberService = memberService;
+        this.reviewService = reviewService;
+        this.reviewServiceImpl = reviewServiceImpl;
     }
 
     @PostMapping("/join")
@@ -94,10 +101,14 @@ public class ProController {
 
     // 달인 서비스 상세보기
     @GetMapping("/item/detail")
-    public ResponseEntity<?> getItemDetails(@RequestParam("proItemNo") Long proItemNo) {
-        ItemDetailResponse itemDetailResponse = proService.getItemDetails(proItemNo);
-
-        return ResponseEntity.ok(ApiResponse.success("조회 성공", itemDetailResponse));
+    public ResponseEntity<?> getItemDetails(@RequestParam("proItemNo") Long proItemNo, @RequestParam(value = "pg", required = false, defaultValue = "1") int pg) {
+        Page<ItemReviewResponse> reviewResponsePage = reviewServiceImpl.getReviewsByItemNo(proItemNo,pg);
+        Map<String, Object> response = new HashMap<>();
+        response.put("content", reviewResponsePage.getContent());
+        response.put("totalPages", reviewResponsePage.getTotalPages());
+        response.put("currentPage", reviewResponsePage.getNumber());
+        response.put("totalElements", reviewResponsePage.getTotalElements());
+        return ResponseEntity.ok(ApiResponse.success("조회 성공", response));
 
     }
 

--- a/src/main/java/com/ncp/moeego/review/bean/ItemReviewResponse.java
+++ b/src/main/java/com/ncp/moeego/review/bean/ItemReviewResponse.java
@@ -1,0 +1,33 @@
+package com.ncp.moeego.review.bean;
+
+import com.ncp.moeego.common.ConvertDate;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ItemReviewResponse {
+    private Long reviewNo;             // 리뷰 번호
+    private String reviewContent;      // 리뷰 내용
+    private float star;                // 별점 (0~5.0)
+    private LocalDateTime writeDate;   // 작성일
+    private String proName;       // 달인 이름
+    private String subject;       // 서비스 이름
+    private String memberName;    // 리뷰 작성자
+    private String elapsedTime;  // 경과 시간 (서비스 계층에서 계산)
+    private Long proItemNo;            // ProItem의 ID
+    private Long memberNo;             // Member의 ID
+
+    public ItemReviewResponse(Long reviewNo, String reviewContent, float star, LocalDateTime writeDate, String proName, String subject, String memberName, Long proItemNo, Long memberNo) {
+        this.reviewNo = reviewNo;
+        this.reviewContent = reviewContent;
+        this.star = star;
+        this.writeDate = writeDate;
+        this.proName = proName;
+        this.subject = subject;
+        this.memberName = memberName;
+        this.proItemNo = proItemNo;
+        this.memberNo = memberNo;
+        this.elapsedTime = ConvertDate.calculateDate(writeDate);
+    }
+}

--- a/src/main/java/com/ncp/moeego/review/bean/ItemReviewResponse.java
+++ b/src/main/java/com/ncp/moeego/review/bean/ItemReviewResponse.java
@@ -4,6 +4,7 @@ import com.ncp.moeego.common.ConvertDate;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 public class ItemReviewResponse {
@@ -17,6 +18,7 @@ public class ItemReviewResponse {
     private String elapsedTime;  // 경과 시간 (서비스 계층에서 계산)
     private Long proItemNo;            // ProItem의 ID
     private Long memberNo;             // Member의 ID
+    private List <String> imageUuidNames; //
 
     public ItemReviewResponse(Long reviewNo, String reviewContent, float star, LocalDateTime writeDate, String proName, String subject, String memberName, Long proItemNo, Long memberNo) {
         this.reviewNo = reviewNo;

--- a/src/main/java/com/ncp/moeego/review/bean/ReviewDTO.java
+++ b/src/main/java/com/ncp/moeego/review/bean/ReviewDTO.java
@@ -40,6 +40,5 @@ public class ReviewDTO {
         this.writeDate = writeDate;
         this.elapsedTime = elapsedTime;
     }
-    
-    
+
 }

--- a/src/main/java/com/ncp/moeego/review/entity/Review.java
+++ b/src/main/java/com/ncp/moeego/review/entity/Review.java
@@ -1,13 +1,14 @@
 package com.ncp.moeego.review.entity;
 
-import com.ncp.moeego.category.entity.MainCategory;
+import com.ncp.moeego.image.entity.Image;
 import com.ncp.moeego.member.entity.Member;
 import com.ncp.moeego.pro.entity.ProItem;
-
 import jakarta.persistence.*;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Data
@@ -26,10 +27,11 @@ public class Review {
 
     @Column(name = "review_content", length = 3000)
     private String reviewContent;
-    
+
     private float star;
 
     @Column(name = "write_date")
     private LocalDateTime writeDate = LocalDateTime.now();
+
 }
 

--- a/src/main/java/com/ncp/moeego/review/repository/ReviewRepository.java
+++ b/src/main/java/com/ncp/moeego/review/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package com.ncp.moeego.review.repository;
 
+import com.ncp.moeego.review.bean.ItemReviewResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -38,5 +39,11 @@ public interface ReviewRepository extends JpaRepository<Review, Long>{
 	Page<Object[]> findReviewsByMemberNo(@Param("memberNo") Long memberNo, Pageable pageable);
 
 
-
+	@Query("""
+select new com.ncp.moeego.review.bean.ItemReviewResponse(
+r.reviewNo,r.reviewContent, r.star, r.writeDate, r.proItem.pro.member.name, r.proItem.subject, r.member.name, r.proItem.proItemNo, r.member.memberNo
+) from Review r
+where r.proItem.proItemNo = :proItemNo
+""")
+	Page<ItemReviewResponse> findReviewsByProItem_ProItemNo(@Param("proItemNo") Long proItemNo, Pageable pageable);
 }

--- a/src/main/java/com/ncp/moeego/review/repository/ReviewRepository.java
+++ b/src/main/java/com/ncp/moeego/review/repository/ReviewRepository.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Repository;
 
 import com.ncp.moeego.review.entity.Review;
 
+import java.util.List;
+
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long>{
 
@@ -46,4 +48,6 @@ r.reviewNo,r.reviewContent, r.star, r.writeDate, r.proItem.pro.member.name, r.pr
 where r.proItem.proItemNo = :proItemNo
 """)
 	Page<ItemReviewResponse> findReviewsByProItem_ProItemNo(@Param("proItemNo") Long proItemNo, Pageable pageable);
+
+
 }

--- a/src/main/java/com/ncp/moeego/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/ncp/moeego/review/service/ReviewServiceImpl.java
@@ -1,11 +1,15 @@
 package com.ncp.moeego.review.service;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import com.ncp.moeego.review.bean.ItemReviewResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -116,6 +120,13 @@ public class ReviewServiceImpl implements ReviewService{
 	                elapsedTime
 	        );
 	    });
+	}
+
+	public Page<ItemReviewResponse> getReviewsByItemNo (Long proItemNo, int pg) {
+		Pageable pageable  = PageRequest.of(pg - 1, 5);
+		Page<ItemReviewResponse> reviewPage = reviewRepository.findReviewsByProItem_ProItemNo(proItemNo, pageable);
+		return reviewPage;
+
 	}
 
 	// 리뷰 삭제

--- a/src/main/java/com/ncp/moeego/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/ncp/moeego/review/service/ReviewServiceImpl.java
@@ -1,20 +1,5 @@
 package com.ncp.moeego.review.service;
 
-import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import com.ncp.moeego.review.bean.ItemReviewResponse;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-
-import com.ncp.moeego.category.entity.MainCategory;
 import com.ncp.moeego.category.repository.MainCategoryRepository;
 import com.ncp.moeego.common.ConvertDate;
 import com.ncp.moeego.image.entity.Image;
@@ -24,178 +9,215 @@ import com.ncp.moeego.member.repository.MemberRepository;
 import com.ncp.moeego.ncp.service.ObjectStorageService;
 import com.ncp.moeego.pro.entity.ProItem;
 import com.ncp.moeego.pro.repository.ProItemRepository;
+import com.ncp.moeego.review.bean.ItemReviewResponse;
 import com.ncp.moeego.review.bean.ReviewDTO;
 import com.ncp.moeego.review.entity.Review;
 import com.ncp.moeego.review.repository.ReviewRepository;
-
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
-public class ReviewServiceImpl implements ReviewService{
-	
-	private final ProItemRepository proItemRepository;
-	private final MainCategoryRepository mainCategoryRepository;
-	private final MemberRepository memberRepository;
-	private final ObjectStorageService objectStorageService;
-	private final ImageRepository imageRepository;
-	private final ReviewRepository reviewRepository;
-	
-	
-	private String bucketName = "moeego";
-	
-	// 리뷰 작성
-	@Override
-	public boolean writeReview(ReviewDTO reviewDTO) {
-	    try {
-	        // ReviewDTO → Review 변환
-	        Review review = new Review();
-	        review.setReviewContent(reviewDTO.getReviewContent());
-	        review.setStar(reviewDTO.getStar());
-	        review.setWriteDate(LocalDateTime.now());
+public class ReviewServiceImpl implements ReviewService {
 
-	        // ProItem 조회 및 설정
-	        ProItem proItem = proItemRepository.findById(reviewDTO.getProItemNo())
-	                .orElseThrow(() -> new IllegalArgumentException("Invalid proItemNo"));
-	        review.setProItem(proItem);
+    private final ProItemRepository proItemRepository;
+    private final MainCategoryRepository mainCategoryRepository;
+    private final MemberRepository memberRepository;
+    private final ObjectStorageService objectStorageService;
+    private final ImageRepository imageRepository;
+    private final ReviewRepository reviewRepository;
 
-	        // Member 조회 및 설정
-	        Member member = memberRepository.findById(reviewDTO.getMemberNo())
-	                .orElseThrow(() -> new IllegalArgumentException("Invalid memberNo"));
-	        review.setMember(member);
 
-	        // Review 저장
-	        Review savedReview = reviewRepository.save(review);
+    private String bucketName = "moeego";
 
-	        // 이미지 업로드 및 저장 (이미지가 있을 경우에만 처리)
-	        if (reviewDTO.getImageFiles() != null && !reviewDTO.getImageFiles().isEmpty()) {
-	            for (MultipartFile imageFile : reviewDTO.getImageFiles()) {
-	                // 1. 오브젝트 스토리지에 업로드
-	                String cloudKey = objectStorageService.uploadFile(bucketName, "storage/", imageFile);
+    // 리뷰 작성
+    @Override
+    public boolean writeReview(ReviewDTO reviewDTO) {
+        try {
+            // ReviewDTO → Review 변환
+            Review review = new Review();
+            review.setReviewContent(reviewDTO.getReviewContent());
+            review.setStar(reviewDTO.getStar());
+            review.setWriteDate(LocalDateTime.now());
 
-	                // 2. 업로드된 이미지 정보를 DB에 저장
-	                Image image = new Image();
-	                image.setReview(savedReview); // 리뷰와 연결
-	                image.setMember(member); // 작성자와 연결
-	                image.setImageName(imageFile.getOriginalFilename());
-	                image.setImageUuidName(cloudKey); // 스토리지의 키 저장
-	                imageRepository.save(image);
-	            }
-	        }
+            // ProItem 조회 및 설정
+            ProItem proItem = proItemRepository.findById(reviewDTO.getProItemNo())
+                    .orElseThrow(() -> new IllegalArgumentException("Invalid proItemNo"));
+            review.setProItem(proItem);
 
-	        return true; 
-	    } catch (Exception e) {
-	        e.printStackTrace();
-	        return false; 
-	    }
-	}
+            // Member 조회 및 설정
+            Member member = memberRepository.findById(reviewDTO.getMemberNo())
+                    .orElseThrow(() -> new IllegalArgumentException("Invalid memberNo"));
+            review.setMember(member);
 
-	// 리뷰 조회
-	@Override
-	public Page<ReviewDTO> getReviewListByPage(int pg, int pageSize) {
+            // Review 저장
+            Review savedReview = reviewRepository.save(review);
 
-	    PageRequest pageRequest = PageRequest.of(pg - 1, pageSize, Sort.by(Sort.Order.desc("writeDate")));
+            // 이미지 업로드 및 저장 (이미지가 있을 경우에만 처리)
+            if (reviewDTO.getImageFiles() != null && !reviewDTO.getImageFiles().isEmpty()) {
+                for (MultipartFile imageFile : reviewDTO.getImageFiles()) {
+                    // 1. 오브젝트 스토리지에 업로드
+                    String cloudKey = objectStorageService.uploadFile(bucketName, "storage/", imageFile);
 
-	    Page<Object[]> reviewPage = reviewRepository.findReviewsWithDetails(pageRequest);
+                    // 2. 업로드된 이미지 정보를 DB에 저장
+                    Image image = new Image();
+                    image.setReview(savedReview); // 리뷰와 연결
+                    image.setMember(member); // 작성자와 연결
+                    image.setImageName(imageFile.getOriginalFilename());
+                    image.setImageUuidName(cloudKey); // 스토리지의 키 저장
+                    imageRepository.save(image);
+                }
+            }
 
-	    return reviewPage.map(result -> {
-	    	Long reviewNo = (Long) result[0];
-	        Review review = (Review) result[1];
-	        float star = (float) result[2]; 
-	        String proName = (String) result[3]; // 달인 이름
-	        String subject = (String) result[4]; // 서비스 이름
-	        String memberName = (String) result[5]; // 리뷰 작성자 이름
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
 
-	        // 작성일 기준 경과 시간 계산
-	        String elapsedTime = ConvertDate.calculateDate(review.getWriteDate());
+    // 리뷰 조회
+    @Override
+    public Page<ReviewDTO> getReviewListByPage(int pg, int pageSize) {
 
-	        return new ReviewDTO(
-	        		reviewNo,
-	                proName,
-	                star,
-	                subject,
-	                review.getReviewContent(),
-	                memberName,
-	                review.getWriteDate(),
-	                elapsedTime
-	        );
-	    });
-	}
+        PageRequest pageRequest = PageRequest.of(pg - 1, pageSize, Sort.by(Sort.Order.desc("writeDate")));
 
-	public Page<ItemReviewResponse> getReviewsByItemNo (Long proItemNo, int pg) {
-		Pageable pageable  = PageRequest.of(pg - 1, 5);
-		Page<ItemReviewResponse> reviewPage = reviewRepository.findReviewsByProItem_ProItemNo(proItemNo, pageable);
-		return reviewPage;
+        Page<Object[]> reviewPage = reviewRepository.findReviewsWithDetails(pageRequest);
 
-	}
+        return reviewPage.map(result -> {
+            Long reviewNo = (Long) result[0];
+            Review review = (Review) result[1];
+            float star = (float) result[2];
+            String proName = (String) result[3]; // 달인 이름
+            String subject = (String) result[4]; // 서비스 이름
+            String memberName = (String) result[5]; // 리뷰 작성자 이름
 
-	// 리뷰 삭제
-	@Override
-	public boolean deleteReview(Long reviewNo) {
-		try {
-			
-			Optional<Review> optionalReview = reviewRepository.findById(reviewNo);
-			
-			if(optionalReview.isPresent()) {
-				Review review = optionalReview.get();
-				
-				// 리뷰와 연결된 이미지 조회
-				List<Image> images = imageRepository.findByReview(review);
-				
-				if(images != null && !images.isEmpty()) {
-					for(Image image : images) {
-						// 오브젝트 스토리지 이미지 삭제
-						objectStorageService.deleteFile(image.getImageUuidName(), bucketName, "storage/");
-						
-						// 이미지 엔티티 삭제
-						imageRepository.delete(image);
-					}
-				}
-				
-				// 리뷰 삭제
-				reviewRepository.deleteById(reviewNo);
-				return true;
-			}
-			
-			
-		} catch (Exception e) {
-			// TODO: handle exception
-		}
-		
-		return false;
-	}
+            // 작성일 기준 경과 시간 계산
+            String elapsedTime = ConvertDate.calculateDate(review.getWriteDate());
 
-	// 내가 작성한 리뷰
-	@Override
-	public Page<ReviewDTO> getMyReviews(Long memberNo, int pg, int pageSize) {
+            return new ReviewDTO(
+                    reviewNo,
+                    proName,
+                    star,
+                    subject,
+                    review.getReviewContent(),
+                    memberName,
+                    review.getWriteDate(),
+                    elapsedTime
+            );
+        });
+    }
 
-	    PageRequest pageRequest = PageRequest.of(pg - 1, pageSize, Sort.by(Sort.Order.desc("writeDate")));
+    public Page<ItemReviewResponse> getReviewsByItemNo(Long proItemNo, int pg) {
+        Pageable pageable = PageRequest.of(pg - 1, 5);
+        Page<ItemReviewResponse> reviewPage = reviewRepository.findReviewsByProItem_ProItemNo(proItemNo, pageable);
 
-	    // memberNo로 리뷰 조회
-	    Page<Object[]> reviewPage = reviewRepository.findReviewsByMemberNo(memberNo, pageRequest);
+        // 리뷰 번호 추출
+        List<Long> reviewNos = reviewPage.getContent().stream().map(ItemReviewResponse::getReviewNo).toList();
 
-	    return reviewPage.map(result -> {
-	        Long reviewNo = (Long) result[0];
-	        Review review = (Review) result[1];
-	        float star = (float) result[2]; 
-	        String proName = (String) result[3]; // 달인 이름
-	        String subject = (String) result[4]; // 서비스 이름
-	        String memberName = (String) result[5]; // 리뷰 작성자 이름
+        // 이미지 데이터를 가져오고 map으로 변환
+        List<Object[]> imageData = imageRepository.findImageUuidsByReviewNos(reviewNos);
 
-	        // 작성일 기준 경과 시간 계산
-	        String elapsedTime = ConvertDate.calculateDate(review.getWriteDate());
+        Map<Long, List<String>> imageMap = imageData.stream()
+                .collect(Collectors.groupingBy(
+                        data -> (Long) data[0], // reviewNo
+                        Collectors.mapping(
+                                data -> (String) data[1], // imageUuidName
+                                Collectors.toList()
+                        )
+                ));
 
-	        return new ReviewDTO(
-	                reviewNo,
-	                proName,
-	                star,
-	                subject,
-	                review.getReviewContent(),
-	                memberName,
-	                review.getWriteDate(),
-	                elapsedTime
-	        );
-	    });
-	}
+        //리뷰 객체에 이미지 uuid 셋팅
+        reviewPage.getContent().forEach(item -> {
+            List<String> imageUuids = imageMap.getOrDefault(item.getReviewNo(), List.of());
+            item.setImageUuidNames(imageUuids);
+        });
+
+        return reviewPage;
+
+    }
+
+
+    // 리뷰 삭제
+    @Override
+    public boolean deleteReview(Long reviewNo) {
+        try {
+
+            Optional<Review> optionalReview = reviewRepository.findById(reviewNo);
+
+            if (optionalReview.isPresent()) {
+                Review review = optionalReview.get();
+
+                // 리뷰와 연결된 이미지 조회
+                List<Image> images = imageRepository.findByReview(review);
+
+                if (images != null && !images.isEmpty()) {
+                    for (Image image : images) {
+                        // 오브젝트 스토리지 이미지 삭제
+                        objectStorageService.deleteFile(image.getImageUuidName(), bucketName, "storage/");
+
+                        // 이미지 엔티티 삭제
+                        imageRepository.delete(image);
+                    }
+                }
+
+                // 리뷰 삭제
+                reviewRepository.deleteById(reviewNo);
+                return true;
+            }
+
+
+        } catch (Exception e) {
+            // TODO: handle exception
+        }
+
+        return false;
+    }
+
+    // 내가 작성한 리뷰
+    @Override
+    public Page<ReviewDTO> getMyReviews(Long memberNo, int pg, int pageSize) {
+
+        PageRequest pageRequest = PageRequest.of(pg - 1, pageSize, Sort.by(Sort.Order.desc("writeDate")));
+
+        // memberNo로 리뷰 조회
+        Page<Object[]> reviewPage = reviewRepository.findReviewsByMemberNo(memberNo, pageRequest);
+
+        return reviewPage.map(result -> {
+            Long reviewNo = (Long) result[0];
+            Review review = (Review) result[1];
+            float star = (float) result[2];
+            String proName = (String) result[3]; // 달인 이름
+            String subject = (String) result[4]; // 서비스 이름
+            String memberName = (String) result[5]; // 리뷰 작성자 이름
+
+            // 작성일 기준 경과 시간 계산
+            String elapsedTime = ConvertDate.calculateDate(review.getWriteDate());
+
+            return new ReviewDTO(
+                    reviewNo,
+                    proName,
+                    star,
+                    subject,
+                    review.getReviewContent(),
+                    memberName,
+                    review.getWriteDate(),
+                    elapsedTime
+            );
+        });
+    }
 
 }


### PR DESCRIPTION
# 구현한 기능
- 달인 상세보기 페이지에 리뷰 반환
# 상세내용 
- /pro/item/detail(get)
- itemNo로 검색해서 연관된 review목록 리턴
- 5개씩 페이징
- 리뷰 객체 하나하나마다 해당되는 imageUuid를 image테이블에서 찾아서 삽입(어렵다)