### PR TITLE
[BE] Ref 관리자 페이지 고수 승인/거절 시 이메일 전송

### DIFF
--- a/src/main/java/com/ncp/moeego/member/controller/AdminController.java
+++ b/src/main/java/com/ncp/moeego/member/controller/AdminController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -124,13 +125,38 @@ public class AdminController {
     }
     
     // 고수 신청 시 이메일 상태 값 확인
-    @GetMapping("")
+    @GetMapping("/admin/emailstatus/{member_no}")
+    public ResponseEntity<?> getEmailStatus(@PathVariable("member_no") long member_no) {
+    	int email_status = memberService.getMemberEmailStatus(member_no);
+    	return ResponseEntity.ok(email_status);
+    }
+    
+    @PatchMapping("/admin/emailstatus/{member_no}")
+    public ResponseEntity<?> updateEmailStatus(@PathVariable("member_no") long member_no) {
+        // 현재 상태 조회
+        int currentStatus = memberService.getMemberEmailStatus(member_no);
+        
+        if (currentStatus == 0) {
+            return ResponseEntity.badRequest().body("이미 email_status가 0입니다.");
+        }
+
+        // 상태를 0으로 변경
+        boolean updated = memberService.updateEmailStatus(member_no, 0); // 새 메서드 작성 필요
+        if (updated) {
+            return ResponseEntity.ok("email_status가 0으로 변경되었습니다.");
+        } else {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                                 .body("email_status 변경 실패");
+        }
+    }
     
     // 고수 승인 버튼 클릭 시
     @PostMapping("/admin/pro/approve/{member_no}")
     public ResponseEntity<ApiResponse> approveMember(@PathVariable("member_no") long member_no) {
         // 이메일 검사
+    	log.info("member_no : " + member_no);
         String email = memberService.getMemberEmail(member_no);
+        log.info("email : " + email);
         if (email == null || email.isEmpty()) {
             return ResponseEntity.badRequest().body(ApiResponse.error("이메일이 유효하지 않습니다.", "BAD_REQUEST"));
         }
@@ -149,8 +175,9 @@ public class AdminController {
             return ResponseEntity.ok(ApiResponse.success("고수 승인 완료", null));
         } else {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                                 .body(ApiResponse.error("승인 실패", "BAD_REQUEST"));
+                                 .body(ApiResponse.error("고수 승인 실패", "BAD_REQUEST"));
         }
+
     }
 
     
@@ -174,10 +201,10 @@ public class AdminController {
     	// member_status 상태 변경
         boolean result = adminService.cancelMember(member_no);
         if (result) {
-            return ResponseEntity.ok(ApiResponse.success("고수 승인 완료", null));
+        	return ResponseEntity.ok(ApiResponse.success("고수 취소 완료", null));
         } else {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                                 .body(ApiResponse.error("승인 실패", "BAD_REQUEST"));
+                                 .body(ApiResponse.error("취소 실패", "BAD_REQUEST"));
         }
     }
     

--- a/src/main/java/com/ncp/moeego/member/service/MemberService.java
+++ b/src/main/java/com/ncp/moeego/member/service/MemberService.java
@@ -15,6 +15,8 @@ public interface MemberService {
 
     String getMemberEmail(Long memberNo);
     
+    Integer getMemberEmailStatus(Long memberNo);
+    
     String getMemberName(Long memberNo);
 
     String getMemberProfileImage(Long memberNo);
@@ -36,6 +38,8 @@ public interface MemberService {
     Long getMemberNo(String email);
 
     void setMemberStatus(Long memberNo, MemberStatus memberStatus);
+
+	boolean updateEmailStatus(long member_no, int currentStatus);
 
 
 }

--- a/src/main/java/com/ncp/moeego/member/service/MemberService.java
+++ b/src/main/java/com/ncp/moeego/member/service/MemberService.java
@@ -13,6 +13,8 @@ public interface MemberService {
 
     Member getMemberByEmail(String email);
 
+    String getMemberEmail(Long memberNo);
+    
     String getMemberName(Long memberNo);
 
     String getMemberProfileImage(Long memberNo);
@@ -34,4 +36,6 @@ public interface MemberService {
     Long getMemberNo(String email);
 
     void setMemberStatus(Long memberNo, MemberStatus memberStatus);
+
+
 }

--- a/src/main/java/com/ncp/moeego/member/service/impl/AdminServiceImpl.java
+++ b/src/main/java/com/ncp/moeego/member/service/impl/AdminServiceImpl.java
@@ -36,6 +36,7 @@ import com.ncp.moeego.image.repository.ImageRepository;
 import com.ncp.moeego.member.bean.MemberSummaryDTO;
 import com.ncp.moeego.member.bean.ProDTO;
 import com.ncp.moeego.member.bean.oauth2.MemberDTO;
+import com.ncp.moeego.member.controller.AdminController;
 import com.ncp.moeego.member.entity.Member;
 import com.ncp.moeego.member.entity.MemberStatus;
 import com.ncp.moeego.member.repository.MemberRepository;
@@ -48,7 +49,9 @@ import com.ncp.moeego.pro.repository.ProItemRepository;
 import com.ncp.moeego.pro.repository.ProRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdminServiceImpl implements AdminService {
@@ -88,10 +91,12 @@ public class AdminServiceImpl implements AdminService {
 	public boolean approveMember(Long member_no) {
 	    // 1. Member 테이블에서 멤버 조회
 	    Member member = memberRepository.findById(member_no).orElse(null);
+	    log.info("member : " + member);
 	    if (member != null && member.getMemberStatus() == MemberStatus.ROLE_PEND_PRO) {
 	        
 	        // 2. Member 테이블에서 상태를 ROLE_PRO로 변경
 	        member.setMemberStatus(MemberStatus.ROLE_PRO);
+	        member.setEmailStatus(1);
 	        memberRepository.save(member);  // 변경된 멤버 저장
 
 	        // 3. Pro 엔티티의 accessDate 값도 현재 날짜로 설정
@@ -139,7 +144,7 @@ public class AdminServiceImpl implements AdminService {
 	    // Member 상태 변경
 	    member.setMemberStatus(MemberStatus.ROLE_USER); // 상태 변경
 	    memberRepository.save(member); // Member 상태 변경 후 저장
-
+	    member.setEmailStatus(1);
 	    return true; // 작업 성공
 	}
 

--- a/src/main/java/com/ncp/moeego/member/service/impl/MailServiceImpl.java
+++ b/src/main/java/com/ncp/moeego/member/service/impl/MailServiceImpl.java
@@ -48,9 +48,10 @@ public class MailServiceImpl {
         try {
             message.setFrom(senderEmail);
             message.setRecipients(MimeMessage.RecipientType.TO, mail);
-            message.setSubject("고수 신청 승인");
-            String body = "<h3>고수 신청이 승인 되었습니다.</h3>" +
-                          "<h3>로그아웃 후 다시 로그인 해주세요.</h3>";
+            message.setSubject("고수 신청 승인 되었습니다");
+            String body = "<h3>축하합니다!</h3>" +
+            			  "<h4>고수 신청이 승인 되었습니다.</h4>" +
+                          "<h4>로그아웃 후 다시 로그인 해주세요.</h4>";
             message.setText(body, "UTF-8", "html");
         } catch (MessagingException e) {
             e.printStackTrace();
@@ -70,9 +71,9 @@ public class MailServiceImpl {
         try {
             message.setFrom(senderEmail);
             message.setRecipients(MimeMessage.RecipientType.TO, mail);
-            message.setSubject("고수 신청 승인");
-            String body = "<h3>고수 신청이 승인 되었습니다.</h3>" +
-                          "<h3>로그아웃 후 다시 로그인 해주세요.</h3>";
+            message.setSubject("고수 신청 취소 되었습니다");
+            String body = "<h3>죄송합니다.</h3>" +
+            		      "<h4>고수 신청이 취소 되었습니다.</h4>";
             message.setText(body, "UTF-8", "html");
         } catch (MessagingException e) {
             e.printStackTrace();
@@ -82,7 +83,7 @@ public class MailServiceImpl {
 
     // 고수 신청 취소 메일 전송
     public void cancelMail(String email) {
-        MimeMessage message = AccessMail(email);
+        MimeMessage message = CancelMail(email);
         javaMailSender.send(message); // 이메일 전송
     }
 }

--- a/src/main/java/com/ncp/moeego/member/service/impl/MailServiceImpl.java
+++ b/src/main/java/com/ncp/moeego/member/service/impl/MailServiceImpl.java
@@ -41,4 +41,48 @@ public class MailServiceImpl {
         javaMailSender.send(message);
         return number;
     }
+    
+    // 고수 신청 승인 이메일 생성
+    public MimeMessage AccessMail(String mail) {
+        MimeMessage message = javaMailSender.createMimeMessage();
+        try {
+            message.setFrom(senderEmail);
+            message.setRecipients(MimeMessage.RecipientType.TO, mail);
+            message.setSubject("고수 신청 승인");
+            String body = "<h3>고수 신청이 승인 되었습니다.</h3>" +
+                          "<h3>로그아웃 후 다시 로그인 해주세요.</h3>";
+            message.setText(body, "UTF-8", "html");
+        } catch (MessagingException e) {
+            e.printStackTrace();
+        }
+        return message;
+    }
+
+    // 고수 신청 승인 메일 전송
+    public void accessMail(String email) {
+        MimeMessage message = AccessMail(email);
+        javaMailSender.send(message); // 이메일 전송
+    }
+    
+ // 고수 신청 취소 이메일 생성
+    public MimeMessage CancelMail(String mail) {
+        MimeMessage message = javaMailSender.createMimeMessage();
+        try {
+            message.setFrom(senderEmail);
+            message.setRecipients(MimeMessage.RecipientType.TO, mail);
+            message.setSubject("고수 신청 승인");
+            String body = "<h3>고수 신청이 승인 되었습니다.</h3>" +
+                          "<h3>로그아웃 후 다시 로그인 해주세요.</h3>";
+            message.setText(body, "UTF-8", "html");
+        } catch (MessagingException e) {
+            e.printStackTrace();
+        }
+        return message;
+    }
+
+    // 고수 신청 취소 메일 전송
+    public void cancelMail(String email) {
+        MimeMessage message = AccessMail(email);
+        javaMailSender.send(message); // 이메일 전송
+    }
 }

--- a/src/main/java/com/ncp/moeego/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/ncp/moeego/member/service/impl/MemberServiceImpl.java
@@ -69,6 +69,11 @@ public class MemberServiceImpl implements MemberService {
     }
     
     @Override
+    public Integer getMemberEmailStatus(Long memberNo) {
+        return getMemberById(memberNo).getEmailStatus();
+    }
+    
+    @Override
     public String getMemberName(Long memberNo) {
         return getMemberById(memberNo).getName();
     }
@@ -184,5 +189,16 @@ public class MemberServiceImpl implements MemberService {
             return ApiResponse.error("회원 탈퇴 처리 중 오류가 발생했습니다. 다시 시도해주세요.", HttpStatus.INTERNAL_SERVER_ERROR.name());
         }
     }
+
+	@Override
+	public boolean updateEmailStatus(long member_no, int currentStatus) {
+		Member member = memberRepository.findById(member_no).orElse(null);
+	    if (member != null) {
+	        member.setEmailStatus(currentStatus);
+	        memberRepository.save(member); // 업데이트 처리
+	        return true;
+	    }
+	    return false;
+	}
 
 }

--- a/src/main/java/com/ncp/moeego/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/ncp/moeego/member/service/impl/MemberServiceImpl.java
@@ -64,6 +64,11 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    public String getMemberEmail(Long memberNo) {
+        return getMemberById(memberNo).getEmail();
+    }
+    
+    @Override
     public String getMemberName(Long memberNo) {
         return getMemberById(memberNo).getName();
     }


### PR DESCRIPTION
[BE] Ref 관리자 페이지 고수 승인/거절 시 이메일 전송

1. @GetMapping("/admin/emailstatus/{member_no}")
  - 로그인 한 사용자의 localStorage의 userno값을 가지고 email_status 값 확인
  - ※ front에서 "const memberNo = localStorage.getItem('userNo');" 이런식으로 받아줘야함

2. @PatchMapping("/admin/emailstatus/{member_no}")
  -  로그인 한 사용자가 알림을 클릭 시 alert 창에서 확인 버튼을 누르면 로그인 한 사용자의 userno 값으로 email_status 값 변경

3. 고수 신청 페이지 에서 승인/거절 버튼 클릭시 email_status 값 " 1 " 로 변경